### PR TITLE
ReyInternalException line116, parameter of String path is nonused (#73)

### DIFF
--- a/src/main/java/io/xream/rey/exception/ReyInternalException.java
+++ b/src/main/java/io/xream/rey/exception/ReyInternalException.java
@@ -117,7 +117,7 @@ public class ReyInternalException extends RuntimeException {
             super();
             RemoteExceptionProto.ExceptionTrace exceptionTrace = new RemoteExceptionProto.ExceptionTrace();
             exceptionTrace.setStack(stack);
-            exceptionTrace.setUri(path)
+            exceptionTrace.setUri(path);
 
             RemoteExceptionProto proto = new RemoteExceptionProto();
             proto.setStatus(400);


### PR DESCRIPTION
fix exceptionTrace.setUri(path);